### PR TITLE
Call Application object instead of the setup

### DIFF
--- a/src/fixtures/configurations.py
+++ b/src/fixtures/configurations.py
@@ -14,21 +14,12 @@ DATA_DIR = os.path.dirname(os.path.dirname(os.path.realpath(__file__))) + "/data
 
 
 @pytest.fixture(scope="function")
-def configurations(
-    config,
-    intellij_config,
-    vscode_config,
-    app_name,
-    analysis_data,
-    ide,
-    setup_intellij,
-    setup_vscode,
-):
+def configurations(config, intellij_config, vscode_config, app_name, analysis_data, ide):
     # region construct configuration object and fill it from the data json
 
     uuid = generate_uuid()
 
-    application = setup_intellij if ide == "intellij" else setup_vscode
+    application = Intellij() if ide == "intellij" else VisualStudioCode()
     application_config = intellij_config if ide == "intellij" else vscode_config
     html_file_location = f"{application_config['plugin_cache_path']}/{uuid}/index.html"
     model_json_path = f"{application_config['plugin_cache_path']}/model.json"


### PR DESCRIPTION
When creating a configuration, instead of passing both setup fixtures for vscode and intellij, it's changed to only create an object of the application, due to 2 reasons:

1. The setup is already called when starting the test
2. This will prevent calling un wanted setup. e.g. when executing for vscode it will only call for vscode.